### PR TITLE
Ops 0 support different endpoints and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,23 @@ Converts json data from a http url into prometheus metrics using jsonpath
 ```yml
 exporter_port: 9158 # Port on which prometheus can call this exporter to get metrics
 log_level: info
-json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
-metric_name_prefix: kong_cluster # All metric names will be prefixed with this value
+json_data_urls
+  - url: http://stubonweb.herokuapp.com/ # Base url to get json data used for fetching metric values
+    app: kong_cluster_1
+    env: developement
+    kind: kong_cluster # All metrics defined in kind "kong_cluster" will be executed on this endpoint
+
 metrics:
-- name: total_nodes # Final metric name will be kong_cluster_total_nodes
-  description: Total number of nodes in kong cluster
-  path: $.total
-- name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
-  description: Number of live nodes in kong cluster
-  path: count($.data[@.status is "alive"])
+  - kind: kong_cluster
+    prefix: kong_cluster # All metric names will be prefixed with this value
+    jsonpath: kong-cluster-status # path to json
+    metric:
+      - name: total_nodes # Final metric name will be kong_cluster_total_nodes
+        description: Total number of nodes in kong cluster
+        path: $.total
+      - name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
+        description: Number of live nodes in kong cluster
+        path: count($.data[@.status is "alive"])
 ```
 
 See the example below to understand how the json data and metrics will look for this config
@@ -43,7 +51,7 @@ This exporter uses [objectpath](http://objectpath.org) python library. The synta
 
 ### Example
 
-For the above config, if the configured `json_data_url` returns
+For the above config, if the configured endpoint returns
 
 ```json
 {
@@ -70,8 +78,16 @@ Metrics will available in http://localhost:9158
 
 
 ```
-$ curl -s localhost:9158 | grep ^kong
-kong_cluster_total_nodes 3.0
-kong_cluster_alive_nodes 2.0
+$ curl -s localhost:9158 | grep -v ^#
+kong_cluster_total_nodes{app="kong_cluster_1",environment="developement",kind="kong_cluster"} 3.0
+kong_cluster_alive_nodes{app="kong_cluster_1",environment="developement",kind="kong_cluster"} 2.0
+python_info{implementation="CPython",major="2",minor="7",patchlevel="13",version="2.7.13"} 1.0
+process_virtual_memory_bytes 1.06336256e+08
+process_resident_memory_bytes 4.2012672e+07
+process_start_time_seconds 1.57537248695e+09
+process_cpu_seconds_total 0.26
+process_open_fds 7.0
+process_max_fds 1.048576e+06
+
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ json_data_urls
     app: kong_cluster_1
     env: developement
     kind: kong_cluster # All metrics defined in kind "kong_cluster" will be executed on this endpoint
+  - url: http://stubonweb.herokuapp.com/ 
+    app: kong_cluster_1
+    env: production
+    kind: kong_cluster 
+  - url: http://stubonweb.herokuapp.com/ 
+    app: kong_cluster_2
+    env: developement
+    kind: kong_cluster 
+  - url: http://stubonweb.herokuapp.com/ 
+    app: kong_cluster_2
+    env: production
+    kind: kong_cluster 
+
 
 metrics:
   - kind: kong_cluster
@@ -81,13 +94,20 @@ Metrics will available in http://localhost:9158
 $ curl -s localhost:9158 | grep -v ^#
 kong_cluster_total_nodes{app="kong_cluster_1",environment="developement",kind="kong_cluster"} 3.0
 kong_cluster_alive_nodes{app="kong_cluster_1",environment="developement",kind="kong_cluster"} 2.0
+kong_cluster_total_nodes{app="kong_cluster_1",environment="production",kind="kong_cluster"} 3.0
+kong_cluster_alive_nodes{app="kong_cluster_1",environment="production",kind="kong_cluster"} 2.0
+kong_cluster_total_nodes{app="kong_cluster_2",environment="developement",kind="kong_cluster"} 3.0
+kong_cluster_alive_nodes{app="kong_cluster_2",environment="developement",kind="kong_cluster"} 2.0
+kong_cluster_total_nodes{app="kong_cluster_2",environment="production",kind="kong_cluster"} 3.0
+kong_cluster_alive_nodes{app="kong_cluster_2",environment="production",kind="kong_cluster"} 2.0
 python_info{implementation="CPython",major="2",minor="7",patchlevel="13",version="2.7.13"} 1.0
-process_virtual_memory_bytes 1.06336256e+08
-process_resident_memory_bytes 4.2012672e+07
-process_start_time_seconds 1.57537248695e+09
-process_cpu_seconds_total 0.26
+process_virtual_memory_bytes 1.06340352e+08
+process_resident_memory_bytes 4.2151936e+07
+process_start_time_seconds 1.57537571808e+09
+process_cpu_seconds_total 0.41000000000000003
 process_open_fds 7.0
 process_max_fds 1.048576e+06
+
 
 ```
 

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -19,16 +19,22 @@ class JsonPathCollector(object):
 
   def collect(self):
     config = self._config
-    result = json.loads(urllib2.urlopen(config['json_data_url'], timeout=10).read())
-    result_tree = Tree(result)
-    for metric_config in config['metrics']:
-      metric_name = "{}_{}".format(config['metric_name_prefix'], metric_config['name'])
-      metric_description = metric_config.get('description', '')
-      metric_path = metric_config['path']
-      value = result_tree.execute(metric_path)
-      logging.debug("metric_name: {}, value for '{}' : {}".format(metric_name, metric_path, value))
-      metric = GaugeMetricFamily(metric_name, metric_description, value=value)
-      yield metric
+    endpoints = config['json_data_urls']
+    for endpoint in endpoints:
+      base_url = endpoint['url']
+      for metric_config in config['metrics']:
+        if endpoint['kind'] == metric_config['kind']:
+          for mymetric in metric_config['metric']:
+            result = json.loads(urllib2.urlopen('{}{}'.format(base_url, metric_config['jsonpath']), timeout=10).read())
+            result_tree = Tree(result)
+            metric_name = "{}_{}".format(metric_config['prefix'], mymetric['name'])
+            metric_description = mymetric.get('description', '')
+            metric_path = mymetric['path']
+            value = result_tree.execute(metric_path)
+            logging.debug("metric_name: {}, value for '{}' : {}".format(metric_name, metric_path, value))
+            metric = GaugeMetricFamily(metric_name, metric_description, labels=["environment","app","kind"])
+            metric.add_metric([endpoint['env'], endpoint['app'], endpoint['kind']] , value=str(value))
+            yield metric
 
 
 if __name__ == "__main__":

--- a/app/exporter.py
+++ b/app/exporter.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
   parser.add_argument('config_file_path', help='Path of the config file')
   args = parser.parse_args()
   with open(args.config_file_path) as config_file:
-    config = yaml.load(config_file)
+    config = yaml.load(config_file, Loader=yaml.FullLoader)
     log_level = config.get('log_level', DEFAULT_LOG_LEVEL)
     logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.getLevelName(log_level.upper()))
     exporter_port = config.get('exporter_port', DEFAULT_PORT)

--- a/example/config.yml
+++ b/example/config.yml
@@ -6,6 +6,18 @@ json_data_urls:
     app: kong_cluster_1
     env: developement
     kind: kong_cluster # All metrics defined in kind "kong_cluster" will be executed for this endpoint
+  - url: http://stubonweb.herokuapp.com/
+    app: kong_cluster_1
+    env: production
+    kind: kong_cluster
+  - url: http://stubonweb.herokuapp.com/
+    app: kong_cluster_2
+    env: developement
+    kind: kong_cluster
+  - url: http://stubonweb.herokuapp.com/
+    app: kong_cluster_2
+    env: production
+    kind: kong_cluster
 
 metrics:
   - kind: kong_cluster

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,12 +1,20 @@
 
-exporter_port: 9158 # Port on which prometheu can call this exporter to get metrics
+exporter_port: 9158 # Port on which prometheus can call this exporter to get metrics
 log_level: info
-json_data_url: http://stubonweb.herokuapp.com/kong-cluster-status # Url to get json data used for fetching metric values
-metric_name_prefix: kong_cluster # All metric names will be prefixed with this value
+json_data_urls:
+  - url: http://stubonweb.herokuapp.com/ # Base url to get json data used for fetching metric values
+    app: kong_cluster_1
+    env: developement
+    kind: kong_cluster # All metrics defined in kind "kong_cluster" will be executed for this endpoint
+
 metrics:
-- name: total_nodes # Final metric name will be kong_cluster_total_nodes
-  description: Total number of nodes in kong cluster
-  path: $.total
-- name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
-  description: Number of live nodes in kong cluster
-  path: count($.data[@.status is "alive"])
+  - kind: kong_cluster
+    prefix: kong_cluster # All metric names will be prefixed with this value
+    jsonpath: kong-cluster-status # path to json
+    metric:
+      - name: total_nodes # Final metric name will be kong_cluster_total_nodes
+        description: Total number of nodes in kong cluster
+        path: $.total
+      - name: alive_nodes # Final metric name will be kong_cluster_alive_nodes
+        description: Number of live nodes in kong cluster
+        path: count($.data[@.status is "alive"])


### PR DESCRIPTION
### changes:
- added/changed labels env, app, kind
- support more then one endpoint
- support more then one json path per endpoint
- support more then one service
- support different metrics for each service/endpoint
- use FullLoader

metrics:
http://monitoring02.ballet.aws.flaconi.net:9999/metrics